### PR TITLE
Allow projects to be quickly added from GitHub repository data

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -8,13 +8,6 @@ use Symfony\Component\Config\Loader\LoaderInterface;
  */
 class AppKernel extends Kernel
 {
-    const RAPID_TRANSIT_VERSION = '0.1.1-DEV';
-    const RAPID_TRANSIT_VERSION_ID = '00101';
-    const RAPID_TRANSIT_MAJOR_VERSION = '0';
-    const RAPID_TRANSIT_MINOR_VERSION = '1';
-    const RAPID_TRANSIT_RELEASE_VERSION = '1';
-    const RAPID_TRANSIT_EXTRA_VERSION = 'DEV';
-
     /**
      * {@inheritdoc}
      */

--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -67,3 +67,4 @@ hwi_oauth:
             type:          github
             client_id:     "%github_client_id%"
             client_secret: "%github_client_secret%"
+            scope:         "repo,read:org"

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
         "doctrine/mongodb-odm-bundle":          "3.0.*@dev",
         "friendsofsymfony/rest-bundle":         "dev-master",
         "friendsofsymfony/user-bundle":         "dev-master",
+        "guzzlehttp/guzzle":                    "~5.0",
         "hwi/oauth-bundle":                     "dev-master",
         "jms/i18n-routing-bundle":              "dev-master",
         "jms/serializer-bundle":                "0.13",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "ae3c4e2d8431d5f39f0975738928da1b",
+    "hash": "966421b51bf43cdaa6b4d7508bf6362c",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -1209,12 +1209,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfSymfony/FOSRestBundle.git",
-                "reference": "721f47ef1f6aec271ed5a73217adbe2db2be089a"
+                "reference": "8c76b05de4b16723855c878f5d081dc2a18e8510"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfSymfony/FOSRestBundle/zipball/721f47ef1f6aec271ed5a73217adbe2db2be089a",
-                "reference": "721f47ef1f6aec271ed5a73217adbe2db2be089a",
+                "url": "https://api.github.com/repos/FriendsOfSymfony/FOSRestBundle/zipball/8c76b05de4b16723855c878f5d081dc2a18e8510",
+                "reference": "8c76b05de4b16723855c878f5d081dc2a18e8510",
                 "shasum": ""
             },
             "require": {
@@ -1278,7 +1278,7 @@
             "keywords": [
                 "rest"
             ],
-            "time": "2014-12-26 09:07:06"
+            "time": "2014-12-29 13:19:19"
         },
         {
             "name": "friendsofsymfony/user-bundle",
@@ -1426,6 +1426,164 @@
                 "uploadable"
             ],
             "time": "2014-01-12 16:34:06"
+        },
+        {
+            "name": "guzzlehttp/guzzle",
+            "version": "5.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "f1085bb4e023766a66b7b051914ec73bdf7202b5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/f1085bb4e023766a66b7b051914ec73bdf7202b5",
+                "reference": "f1085bb4e023766a66b7b051914ec73bdf7202b5",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/ringphp": "~1.0",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "phpunit/phpunit": "~4.0",
+                "psr/log": "~1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle is a PHP HTTP client library and framework for building RESTful web service clients",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "rest",
+                "web service"
+            ],
+            "time": "2014-12-19 20:27:15"
+        },
+        {
+            "name": "guzzlehttp/ringphp",
+            "version": "1.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/RingPHP.git",
+                "reference": "a903f51b692427318bc813217c0e6505287e79a4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/RingPHP/zipball/a903f51b692427318bc813217c0e6505287e79a4",
+                "reference": "a903f51b692427318bc813217c0e6505287e79a4",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/streams": "~3.0",
+                "php": ">=5.4.0",
+                "react/promise": "~2.0"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "phpunit/phpunit": "~4.0"
+            },
+            "suggest": {
+                "ext-curl": "Guzzle will use specific adapters if cURL is present"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Ring\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "time": "2014-12-11 05:50:32"
+        },
+        {
+            "name": "guzzlehttp/streams",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/streams.git",
+                "reference": "47aaa48e27dae43d39fc1cea0ccf0d84ac1a2ba5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/streams/zipball/47aaa48e27dae43d39fc1cea0ccf0d84ac1a2ba5",
+                "reference": "47aaa48e27dae43d39fc1cea0ccf0d84ac1a2ba5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Stream\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Provides a simple abstraction over streams of data",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "Guzzle",
+                "stream"
+            ],
+            "time": "2014-10-12 19:18:40"
         },
         {
             "name": "hwi/oauth-bundle",
@@ -2063,16 +2221,16 @@
         },
         {
             "name": "monolog/monolog",
-            "version": "1.11.0",
+            "version": "1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "ec3961874c43840e96da3a8a1ed20d8c73d7e5aa"
+                "reference": "1fbe8c2641f2b163addf49cc5e18f144bec6b19f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/ec3961874c43840e96da3a8a1ed20d8c73d7e5aa",
-                "reference": "ec3961874c43840e96da3a8a1ed20d8c73d7e5aa",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/1fbe8c2641f2b163addf49cc5e18f144bec6b19f",
+                "reference": "1fbe8c2641f2b163addf49cc5e18f144bec6b19f",
                 "shasum": ""
             },
             "require": {
@@ -2086,7 +2244,7 @@
                 "aws/aws-sdk-php": "~2.4, >2.4.8",
                 "doctrine/couchdb": "~1.0@dev",
                 "graylog2/gelf-php": "~1.0",
-                "phpunit/phpunit": "~3.7.0",
+                "phpunit/phpunit": "~4.0",
                 "raven/raven": "~0.5",
                 "ruflin/elastica": "0.90.*",
                 "videlalvaro/php-amqplib": "~2.4"
@@ -2105,7 +2263,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.11.x-dev"
+                    "dev-master": "1.12.x-dev"
                 }
             },
             "autoload": {
@@ -2131,7 +2289,7 @@
                 "logging",
                 "psr-3"
             ],
-            "time": "2014-09-30 13:30:58"
+            "time": "2014-12-29 21:29:35"
         },
         {
             "name": "nikic/php-parser",
@@ -2536,18 +2694,62 @@
             "time": "2012-12-21 11:40:51"
         },
         {
+            "name": "react/promise",
+            "version": "v2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/promise.git",
+                "reference": "365fcee430dfa4ace1fbc75737ca60ceea7eeeef"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/promise/zipball/365fcee430dfa4ace1fbc75737ca60ceea7eeeef",
+                "reference": "365fcee430dfa4ace1fbc75737ca60ceea7eeeef",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "React\\Promise\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@googlemail.com"
+                }
+            ],
+            "description": "A lightweight implementation of CommonJS Promises/A for PHP",
+            "time": "2014-12-30 13:32:42"
+        },
+        {
             "name": "sensio/distribution-bundle",
-            "version": "v3.0.13",
+            "version": "v3.0.14",
             "target-dir": "Sensio/Bundle/DistributionBundle",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sensiolabs/SensioDistributionBundle.git",
-                "reference": "a46e422c1135f2efa27b72a94e58852849134420"
+                "reference": "dc20d5ab3251587b047859ca2fc06c1b88a38d00"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sensiolabs/SensioDistributionBundle/zipball/a46e422c1135f2efa27b72a94e58852849134420",
-                "reference": "a46e422c1135f2efa27b72a94e58852849134420",
+                "url": "https://api.github.com/repos/sensiolabs/SensioDistributionBundle/zipball/dc20d5ab3251587b047859ca2fc06c1b88a38d00",
+                "reference": "dc20d5ab3251587b047859ca2fc06c1b88a38d00",
                 "shasum": ""
             },
             "require": {
@@ -2586,7 +2788,7 @@
                 "configuration",
                 "distribution"
             ],
-            "time": "2014-12-17 06:40:12"
+            "time": "2014-12-30 08:41:47"
         },
         {
             "name": "sensio/framework-extra-bundle",
@@ -3005,16 +3207,16 @@
         },
         {
             "name": "symfony/monolog-bundle",
-            "version": "v2.6.1",
+            "version": "v2.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/MonologBundle.git",
-                "reference": "227bbeefe30f2d95e3fe5fbd1ccda414287a957a"
+                "reference": "e8f71c91a3784f3fa1a75fb1f7f4d4826c5f2773"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/MonologBundle/zipball/227bbeefe30f2d95e3fe5fbd1ccda414287a957a",
-                "reference": "227bbeefe30f2d95e3fe5fbd1ccda414287a957a",
+                "url": "https://api.github.com/repos/symfony/MonologBundle/zipball/e8f71c91a3784f3fa1a75fb1f7f4d4826c5f2773",
+                "reference": "e8f71c91a3784f3fa1a75fb1f7f4d4826c5f2773",
                 "shasum": ""
             },
             "require": {
@@ -3032,7 +3234,7 @@
             "type": "symfony-bundle",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.6.x-dev"
+                    "dev-master": "2.7.x-dev"
                 }
             },
             "autoload": {
@@ -3060,7 +3262,7 @@
                 "log",
                 "logging"
             ],
-            "time": "2014-07-21 00:36:06"
+            "time": "2014-12-28 16:37:56"
         },
         {
             "name": "symfony/swiftmailer-bundle",
@@ -4225,29 +4427,36 @@
         },
         {
             "name": "fabpot/goutte",
-            "version": "v2.0.2",
+            "version": "v1.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/Goutte.git",
-                "reference": "b12c3f7ec68d8814b50444cfe142fd0a056557f9"
+                "reference": "794b196e76bdd37b5155cdecbad311f0a3b07625"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/Goutte/zipball/b12c3f7ec68d8814b50444cfe142fd0a056557f9",
-                "reference": "b12c3f7ec68d8814b50444cfe142fd0a056557f9",
+                "url": "https://api.github.com/repos/FriendsOfPHP/Goutte/zipball/794b196e76bdd37b5155cdecbad311f0a3b07625",
+                "reference": "794b196e76bdd37b5155cdecbad311f0a3b07625",
                 "shasum": ""
             },
             "require": {
-                "guzzlehttp/guzzle": "4.*",
-                "php": ">=5.4.0",
+                "ext-curl": "*",
+                "guzzle/http": "~3.1",
+                "php": ">=5.3.0",
                 "symfony/browser-kit": "~2.1",
                 "symfony/css-selector": "~2.1",
-                "symfony/dom-crawler": "~2.1"
+                "symfony/dom-crawler": "~2.1",
+                "symfony/finder": "~2.1",
+                "symfony/process": "~2.1"
+            },
+            "require-dev": {
+                "guzzle/plugin-history": "~3.1",
+                "guzzle/plugin-mock": "~3.1"
             },
             "type": "application",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "1.0-dev"
                 }
             },
             "autoload": {
@@ -4270,7 +4479,7 @@
             "keywords": [
                 "scraper"
             ],
-            "time": "2014-07-22 13:24:11"
+            "time": "2014-10-09 15:52:51"
         },
         {
             "name": "fabpot/php-cs-fixer",
@@ -4376,103 +4585,83 @@
             "time": "2014-06-04 14:43:02"
         },
         {
-            "name": "guzzlehttp/guzzle",
-            "version": "4.2.3",
+            "name": "guzzle/common",
+            "version": "v3.9.2",
+            "target-dir": "Guzzle/Common",
             "source": {
                 "type": "git",
-                "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "66fd916e9f9130bc22c51450476823391cb2f67c"
+                "url": "https://github.com/guzzle/common.git",
+                "reference": "2e36af7cf2ce3ea1f2d7c2831843b883a8e7b7dc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/66fd916e9f9130bc22c51450476823391cb2f67c",
-                "reference": "66fd916e9f9130bc22c51450476823391cb2f67c",
+                "url": "https://api.github.com/repos/guzzle/common/zipball/2e36af7cf2ce3ea1f2d7c2831843b883a8e7b7dc",
+                "reference": "2e36af7cf2ce3ea1f2d7c2831843b883a8e7b7dc",
                 "shasum": ""
             },
             "require": {
-                "ext-json": "*",
-                "guzzlehttp/streams": "~2.1",
-                "php": ">=5.4.0"
-            },
-            "require-dev": {
-                "ext-curl": "*",
-                "phpunit/phpunit": "~4.0",
-                "psr/log": "~1.0"
-            },
-            "suggest": {
-                "ext-curl": "Guzzle will use specific adapters if cURL is present"
+                "php": ">=5.3.2",
+                "symfony/event-dispatcher": ">=2.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "3.7-dev"
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "GuzzleHttp\\": "src/"
-                },
-                "files": [
-                    "src/functions.php"
-                ]
+                "psr-0": {
+                    "Guzzle\\Common": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
-            "authors": [
-                {
-                    "name": "Michael Dowling",
-                    "email": "mtdowling@gmail.com",
-                    "homepage": "https://github.com/mtdowling"
-                }
-            ],
-            "description": "Guzzle is a PHP HTTP client library and framework for building RESTful web service clients",
+            "description": "Common libraries used by Guzzle",
             "homepage": "http://guzzlephp.org/",
             "keywords": [
-                "client",
-                "curl",
-                "framework",
-                "http",
-                "http client",
-                "rest",
-                "web service"
+                "collection",
+                "common",
+                "event",
+                "exception"
             ],
-            "time": "2014-10-05 19:29:14"
+            "time": "2014-08-11 04:32:36"
         },
         {
-            "name": "guzzlehttp/streams",
-            "version": "2.1.0",
+            "name": "guzzle/http",
+            "version": "v3.9.2",
+            "target-dir": "Guzzle/Http",
             "source": {
                 "type": "git",
-                "url": "https://github.com/guzzle/streams.git",
-                "reference": "f91b721d73f0e561410903b3b3c90a5d0e40b534"
+                "url": "https://github.com/guzzle/http.git",
+                "reference": "1e8dd1e2ba9dc42332396f39fbfab950b2301dc5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/streams/zipball/f91b721d73f0e561410903b3b3c90a5d0e40b534",
-                "reference": "f91b721d73f0e561410903b3b3c90a5d0e40b534",
+                "url": "https://api.github.com/repos/guzzle/http/zipball/1e8dd1e2ba9dc42332396f39fbfab950b2301dc5",
+                "reference": "1e8dd1e2ba9dc42332396f39fbfab950b2301dc5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4.0"
+                "guzzle/common": "self.version",
+                "guzzle/parser": "self.version",
+                "guzzle/stream": "self.version",
+                "php": ">=5.3.2"
             },
-            "require-dev": {
-                "phpunit/phpunit": "~4.0"
+            "suggest": {
+                "ext-curl": "*"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "3.7-dev"
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "GuzzleHttp\\Stream\\": "src/"
-                },
-                "files": [
-                    "src/functions.php"
-                ]
+                "psr-0": {
+                    "Guzzle\\Http": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -4485,13 +4674,113 @@
                     "homepage": "https://github.com/mtdowling"
                 }
             ],
-            "description": "Provides a simple abstraction over streams of data (Guzzle 4+)",
+            "description": "HTTP libraries used by Guzzle",
             "homepage": "http://guzzlephp.org/",
             "keywords": [
                 "Guzzle",
+                "client",
+                "curl",
+                "http",
+                "http client"
+            ],
+            "time": "2014-08-11 04:32:36"
+        },
+        {
+            "name": "guzzle/parser",
+            "version": "v3.9.2",
+            "target-dir": "Guzzle/Parser",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/parser.git",
+                "reference": "6874d171318a8e93eb6d224cf85e4678490b625c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/parser/zipball/6874d171318a8e93eb6d224cf85e4678490b625c",
+                "reference": "6874d171318a8e93eb6d224cf85e4678490b625c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Guzzle\\Parser": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Interchangeable parsers used by Guzzle",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "URI Template",
+                "cookie",
+                "http",
+                "message",
+                "url"
+            ],
+            "time": "2014-02-05 18:29:46"
+        },
+        {
+            "name": "guzzle/stream",
+            "version": "v3.9.2",
+            "target-dir": "Guzzle/Stream",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/stream.git",
+                "reference": "60c7fed02e98d2c518dae8f97874c8f4622100f0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/stream/zipball/60c7fed02e98d2c518dae8f97874c8f4622100f0",
+                "reference": "60c7fed02e98d2c518dae8f97874c8f4622100f0",
+                "shasum": ""
+            },
+            "require": {
+                "guzzle/common": "self.version",
+                "php": ">=5.3.2"
+            },
+            "suggest": {
+                "guzzle/http": "To convert Guzzle request objects to PHP streams"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Guzzle\\Stream": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle stream wrapper component",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "Guzzle",
+                "component",
                 "stream"
             ],
-            "time": "2014-08-17 21:15:53"
+            "time": "2014-05-01 21:36:02"
         },
         {
             "name": "instaclick/php-webdriver",
@@ -4956,6 +5245,7 @@
         "fzaninotto/faker": 20
     },
     "prefer-stable": false,
+    "prefer-lowest": false,
     "platform": {
         "php": "~5.4"
     },

--- a/features/creating-projects.feature
+++ b/features/creating-projects.feature
@@ -1,4 +1,0 @@
-Feature: Creating projects for deployment
-  In order to deploy a project
-  As a user
-  I need to be able to create a new project

--- a/features/initializing-projects.feature
+++ b/features/initializing-projects.feature
@@ -1,0 +1,4 @@
+Feature: Initializing projects for deployment
+  In order to deploy a project
+  As a user
+  I need to be able to initialize a new project

--- a/spec/Transit/UserBundle/Security/UserProviderSpec.php
+++ b/spec/Transit/UserBundle/Security/UserProviderSpec.php
@@ -1,0 +1,191 @@
+<?php
+
+namespace spec\Transit\UserBundle\Security;
+
+use FOS\UserBundle\Model\UserManagerInterface;
+use HWI\Bundle\OAuthBundle\OAuth\ResourceOwnerInterface;
+use HWI\Bundle\OAuthBundle\OAuth\Response\UserResponseInterface;
+use HWI\Bundle\OAuthBundle\Security\Core\User\OAuthUser;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Sylius\Bundle\ResourceBundle\Doctrine\ODM\MongoDB\DocumentRepository;
+use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Transit\WebBundle\Model\OauthAccount;
+use Transit\WebBundle\Model\UserAccount;
+
+class UserProviderSpec extends ObjectBehavior
+{
+    function let(UserManagerInterface $userManager, DocumentRepository $oauthAccountRepository, TokenStorage $tokenStorage, AnonymousToken $anonymousToken)
+    {
+        $tokenStorage->getToken()->willReturn($anonymousToken);
+        $anonymousToken->isAuthenticated()->willReturn(false);
+        $anonymousToken->getUser()->shouldNotBeCalled();
+
+        $this->beConstructedWith($userManager, $oauthAccountRepository, $tokenStorage);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Transit\UserBundle\Security\UserProvider');
+    }
+
+    function it_implements_the_HWI_OAuth_aware_user_provider_interface()
+    {
+        $this->shouldImplement('HWI\Bundle\OAuthBundle\Security\Core\User\OAuthAwareUserProviderInterface');
+    }
+
+    function it_should_connect_an_OAuth_account_with_a_given_user(
+        UserManagerInterface $userManager, DocumentRepository $oauthAccountRepository, UserAccount $user, UserResponseInterface $response, ResourceOwnerInterface $resourceOwner, OauthAccount $oauth
+    ) {
+        $resourceOwner->getName()->willReturn('github');
+
+        $response->getUsername()->willReturn('username');
+        $response->getNickname()->willReturn('user');
+        $response->getRealName()->willReturn('John Doh');
+        $response->getProfilePicture()->willReturn('http://example.com/pic.jpg');
+        $response->getResourceOwner()->willReturn($resourceOwner);
+        $response->getAccessToken()->willReturn('access_token');
+
+        $oauthAccountRepository->createNew()->willReturn($oauth);
+
+        $oauth->setIdentifier('username')->shouldBeCalled();
+        $oauth->setProvider('github')->shouldBeCalled();
+        $oauth->setAccessToken('access_token')->shouldBeCalled();
+        $oauth->setNickname('user')->shouldBeCalled();
+        $oauth->setRealName('John Doh')->shouldBeCalled();
+        $oauth->setProfilePicture('http://example.com/pic.jpg')->shouldBeCalled();
+
+        $user->addOauthAccount($oauth)->shouldBeCalled();
+
+        $userManager->updateUser($user)->shouldBeCalled();
+
+        $this->connect($user, $response);
+    }
+
+    function it_returns_the_user_if_relation_exists(
+        DocumentRepository $oauthAccountRepository, OAuthUser $user, UserResponseInterface $response, ResourceOwnerInterface $resourceOwner, OauthAccount $oauth
+    ) {
+        $resourceOwner->getName()->willReturn('github');
+
+        $response->getEmail()->willReturn('username@email');
+        $response->getUsername()->willReturn('username');
+        $response->getNickname()->willReturn('user');
+        $response->getRealName()->willReturn('John Doh');
+        $response->getProfilePicture()->willReturn('http://example.com/pic.jpg');
+        $response->getResourceOwner()->willReturn($resourceOwner);
+
+        $oauthAccountRepository->findOneBy(array('provider' => 'github', 'identifier' => 'username'))->willReturn($oauth);
+
+        $oauth->getUserAccount()->willReturn($user);
+
+        $this->loadUserByOAuthUserResponse($response)->shouldReturn($user);
+    }
+
+    function it_should_update_the_user_when_the_user_was_found_by_email(
+        UserManagerInterface $userManager, DocumentRepository $oauthAccountRepository, UserAccount $user, UserResponseInterface $response, ResourceOwnerInterface $resourceOwner, OauthAccount $oauth
+    ) {
+        $resourceOwner->getName()->willReturn('github');
+
+        $response->getEmail()->willReturn('username@email');
+        $response->getUsername()->willReturn('username');
+        $response->getNickname()->willReturn('user');
+        $response->getRealName()->willReturn('John Doh');
+        $response->getProfilePicture()->willReturn('http://example.com/pic.jpg');
+        $response->getResourceOwner()->willReturn($resourceOwner);
+        $response->getAccessToken()->willReturn('access_token');
+
+        $oauthAccountRepository->findOneBy(array('provider' => 'github', 'identifier' => 'username'))->willReturn(null);
+        $userManager->findUserByEmail('username@email')->willReturn($user);
+
+        $oauthAccountRepository->createNew()->willReturn($oauth);
+
+        $oauth->setIdentifier('username');
+        $oauth->setProvider('github');
+        $oauth->setAccessToken('access_token');
+        $oauth->setNickname('user');
+        $oauth->setRealName('John Doh');
+        $oauth->setProfilePicture('http://example.com/pic.jpg');
+
+        $user->addOauthAccount($oauth)->shouldBeCalled();
+
+        $userManager->updateUser($user)->shouldBeCalled();
+
+        $this->loadUserByOAuthUserResponse($response)->shouldReturn($user);
+    }
+
+    function it_should_update_the_user_when_the_user_was_found_by_email_and_already_authenticated(
+        UserManagerInterface $userManager, DocumentRepository $oauthAccountRepository, UserAccount $user, UserResponseInterface $response, ResourceOwnerInterface $resourceOwner, OauthAccount $oauth, TokenStorageInterface $tokenStorage, TokenInterface $token
+    ) {
+        $tokenStorage->getToken()->willReturn($token);
+        $token->isAuthenticated()->willReturn(true);
+
+        $resourceOwner->getName()->willReturn('github');
+
+        $response->getEmail()->willReturn('username@email');
+        $response->getUsername()->willReturn('username');
+        $response->getNickname()->willReturn('user');
+        $response->getRealName()->willReturn('John Doh');
+        $response->getProfilePicture()->willReturn('http://example.com/pic.jpg');
+        $response->getResourceOwner()->willReturn($resourceOwner);
+        $response->getAccessToken()->willReturn('access_token');
+
+        $oauthAccountRepository->findOneBy(array('provider' => 'github', 'identifier' => 'username'))->willReturn(null);
+        $userManager->findUserByEmail(Argument::any())->shouldNotBeCalled();
+
+        $token->getUser()->willReturn($user);
+
+        $oauthAccountRepository->createNew()->willReturn($oauth);
+
+        $oauth->setIdentifier('username');
+        $oauth->setProvider('github');
+        $oauth->setAccessToken('access_token');
+        $oauth->setNickname('user');
+        $oauth->setRealName('John Doh');
+        $oauth->setProfilePicture('http://example.com/pic.jpg');
+
+        $user->addOauthAccount($oauth)->shouldBeCalled();
+
+        $userManager->updateUser($user)->shouldBeCalled();
+
+        $this->loadUserByOAuthUserResponse($response)->shouldReturn($user);
+    }
+
+    function it_should_create_a_new_user_when_none_was_found(
+        UserManagerInterface $userManager, DocumentRepository $oauthAccountRepository, UserAccount $user, UserResponseInterface $response, ResourceOwnerInterface $resourceOwner, OauthAccount $oauth
+    ) {
+        $resourceOwner->getName()->willReturn('github');
+
+        $response->getEmail()->willReturn(null);
+        $response->getUsername()->willReturn('username');
+        $response->getNickname()->willReturn('user');
+        $response->getRealName()->willReturn('John Doh');
+        $response->getProfilePicture()->willReturn('http://example.com/pic.jpg');
+        $response->getResourceOwner()->willReturn($resourceOwner);
+        $response->getAccessToken()->willReturn('access_token');
+
+        $oauthAccountRepository->findOneBy(array('provider' => 'github', 'identifier' => 'username'))->willReturn(null);
+        $oauthAccountRepository->createNew()->willReturn($oauth);
+
+        $userManager->createUser()->willReturn($user);
+
+        $oauth->setIdentifier('username');
+        $oauth->setProvider('github');
+        $oauth->setAccessToken('access_token');
+        $oauth->setNickname('user');
+        $oauth->setRealName('John Doh');
+        $oauth->setProfilePicture('http://example.com/pic.jpg');
+
+        $user->getUsername()->willReturn(null);
+        $user->setUsername('user')->shouldBeCalled();
+        $user->setPlainPassword('2ff2dfe363')->shouldBeCalled();
+        $user->setEnabled(true)->shouldBeCalled();
+        $user->addOauthAccount($oauth)->shouldBeCalled();
+
+        $userManager->updateUser($user)->shouldBeCalled();
+
+        $this->loadUserByOAuthUserResponse($response)->shouldReturn($user);
+    }
+}

--- a/spec/Transit/WebBundle/EventListener/AccountNotLinkedToGithubListenerSpec.php
+++ b/spec/Transit/WebBundle/EventListener/AccountNotLinkedToGithubListenerSpec.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace spec\Transit\WebBundle\EventListener;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Symfony\Component\Routing\RouterInterface;
+use Transit\WebBundle\Exception\AccountNotLinkedToGithubException;
+
+class AccountNotLinkedToGithubListenerSpec extends ObjectBehavior
+{
+    function let(RouterInterface $router)
+    {
+        $this->beConstructedWith($router);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Transit\WebBundle\EventListener\AccountNotLinkedToGithubListener');
+    }
+
+    function it_ignores_irrelavent_exceptions(GetResponseForExceptionEvent $event, \Exception $anyOtherException, RouterInterface $router)
+    {
+        $event->getException()->willReturn($anyOtherException);
+
+        $router->generate(Argument::any())->shouldNotBeCalled();
+        $event->setResponse(Argument::any())->shouldNotBeCalled();
+
+        $this->onKernelException($event);
+    }
+
+    function it_redirects_to_the_GitHub_account_connect_page_when_the_user_does_not_have_an_OAuth_connection_to_GitHub(
+        GetResponseForExceptionEvent $event, AccountNotLinkedToGithubException $exception, RouterInterface $router
+    ) {
+        $event->getException()->willReturn($exception);
+
+        $router->generate('hwi_oauth_service_redirect', ['service' => 'github'])->willReturn('/oauth/connect/github');
+
+        $redirect = new RedirectResponse('/oauth/connect/github', RedirectResponse::HTTP_FOUND);
+        $event->setResponse($redirect)->shouldBeCalled();
+
+        $this->onKernelException($event);
+    }
+}

--- a/spec/Transit/WebBundle/Github/GithubAccountSpec.php
+++ b/spec/Transit/WebBundle/Github/GithubAccountSpec.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace spec\Transit\WebBundle\Github;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Message\Request;
+use GuzzleHttp\Message\Response;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Transit\WebBundle\Github\Repository;
+
+class GithubAccountSpec extends ObjectBehavior
+{
+    function let(Client $client)
+    {
+        $this->beConstructedThrough('createWithOauthToken', ['abcdef123', $client]);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Transit\WebBundle\Github\GithubAccount');
+    }
+
+    function it_fetches_all_the_accessible_repositories_for_the_user(
+        Client $client,
+        Request $userReposRequest, Response $userReposResponse,
+        Request $userOrgsRequest, Response $userOrgsResponse,
+        Request $orgReposRequest, Response $orgReposResponse
+    ) {
+        // User Repositories
+
+        $client->createRequest('GET', '/user/repos', [
+            'query' => [
+                'sort' => 'name',
+                'type' => 'all',
+                'access_token' => 'abcdef123',
+            ]
+        ])->willReturn($userReposRequest);
+
+        $client->send($userReposRequest)->willReturn($userReposResponse);
+
+        $userReposResponse->json()->willReturn([
+            [
+                'full_name' => 'adamelso/rapid-transit',
+                'html_url' => 'https://github.com/adamelso/rapid-transit',
+                'ssh_url' => 'git@github.com:adamelso/rapid-transit.git',
+            ]
+        ]);
+
+        // User Organizations
+
+        $client->createRequest('GET', '/user/orgs', [
+            'query' => [
+                'access_token' => 'abcdef123',
+            ]
+        ])->willReturn($userOrgsRequest);
+
+        $client->send($userOrgsRequest)->willReturn($userOrgsResponse);
+
+        $userOrgsResponse->json()->willReturn([
+            [
+                'repos_url' => 'https://api.github.com/orgs/archfizz/repos',
+            ]
+        ]);
+
+        // User Organizations' Repositories
+
+        $client->createRequest('GET', 'https://api.github.com/orgs/archfizz/repos', [
+            'query' => [
+                'type' => 'all',
+                'access_token' => 'abcdef123',
+            ]
+        ])->willReturn($orgReposRequest);
+
+        $client->send($orgReposRequest)->willReturn($orgReposResponse);
+
+        $orgReposResponse->json()->willReturn([
+            [
+                'full_name' => 'archfizz/phpairplay',
+                'html_url' => 'https://github.com/archfizz/phpairplay',
+                'ssh_url' => 'git@github.com:archfizz/phpairplay.git',
+            ]
+        ]);
+
+        // All
+
+        $userRepo = new Repository();
+
+        $userRepo
+            ->setFullName('adamelso/rapid-transit')
+            ->setHtmlUrl('https://github.com/adamelso/rapid-transit')
+            ->setSshUrl('git@github.com:adamelso/rapid-transit.git')
+        ;
+
+        $orgRepo = new Repository();
+
+        $orgRepo
+            ->setFullName('archfizz/phpairplay')
+            ->setHtmlUrl('https://github.com/archfizz/phpairplay')
+            ->setSshUrl('git@github.com:archfizz/phpairplay.git')
+        ;
+
+
+        $this->getAccessibleRepositories()->shouldBeLike([$userRepo, $orgRepo]);
+    }
+}

--- a/src/Transit/UserBundle/Resources/config/services.xml
+++ b/src/Transit/UserBundle/Resources/config/services.xml
@@ -9,6 +9,7 @@
         <service id="transit.user.provider" class="Transit\UserBundle\Security\UserProvider">
             <argument type="service" id="fos_user.user_manager" />
             <argument type="service" id="transit.repository.oauth_account" />
+            <argument type="service" id="security.token_storage" />
         </service>
     </services>
 </container>

--- a/src/Transit/WebBundle/Controller/ProjectController.php
+++ b/src/Transit/WebBundle/Controller/ProjectController.php
@@ -3,7 +3,31 @@
 namespace Transit\WebBundle\Controller;
 
 use Sylius\Bundle\ResourceBundle\Controller\ResourceController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * @author Adam Elsodaney <adam.elso@gmail.com>
+ */
 class ProjectController extends ResourceController
 {
+    /**
+     * Provides quick adding of projects by using data from GitHub.
+     *
+     * @param Request $request
+     *
+     * @return Response
+     */
+    public function importAction(Request $request)
+    {
+        $view = $this
+            ->view()
+            ->setTemplate($this->config->getTemplate('import.html'))
+            ->setData([
+                'repositories' => $this->get('transit.provider.account.github')->getAccessibleRepositories(),
+            ])
+        ;
+
+        return $this->handleView($view);
+    }
 }

--- a/src/Transit/WebBundle/EventListener/AccountNotLinkedToGithubListener.php
+++ b/src/Transit/WebBundle/EventListener/AccountNotLinkedToGithubListener.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Transit\WebBundle\EventListener;
+
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Symfony\Component\Routing\RouterInterface;
+use Transit\WebBundle\Exception\AccountNotLinkedToGithubException;
+
+class AccountNotLinkedToGithubListener
+{
+    /**
+     * @var RouterInterface
+     */
+    private $router;
+
+    /**
+     * @param RouterInterface $router
+     */
+    public function __construct(RouterInterface $router)
+    {
+        $this->router = $router;
+    }
+
+    /**
+     * @param GetResponseForExceptionEvent $event
+     */
+    public function onKernelException(GetResponseForExceptionEvent $event)
+    {
+        $e = $event->getException();
+
+        if (! $e instanceof AccountNotLinkedToGithubException) {
+            return;
+        }
+
+        $event->setResponse(new RedirectResponse($this->router->generate('hwi_oauth_service_redirect', ['service' => 'github'])));
+    }
+}

--- a/src/Transit/WebBundle/Exception/AccountNotLinkedToGithubException.php
+++ b/src/Transit/WebBundle/Exception/AccountNotLinkedToGithubException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Transit\WebBundle\Exception;
+
+/**
+ * If a user wants to use data fetched from GitHub, but has not linked
+ * their account to GitHub, this exception should be thrown and caught.
+ *
+ * @author Adam Elsodaney <adam.elso@gmail.com>
+ */
+class AccountNotLinkedToGithubException extends \UnexpectedValueException
+{
+}

--- a/src/Transit/WebBundle/Github/Account.php
+++ b/src/Transit/WebBundle/Github/Account.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Transit\WebBundle\Github;
+
+/**
+ * Classes that will make request to the GitHub API for an authenticated user or otherwise,
+ * should implement this interface.
+ *
+ * @author Adam Elsodaney <adam.elso@gmail.com>
+ */
+interface Account
+{
+    /**
+     * @return array
+     */
+    public function getAccessibleRepositories();
+}

--- a/src/Transit/WebBundle/Github/GithubAccount.php
+++ b/src/Transit/WebBundle/Github/GithubAccount.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Transit\WebBundle\Github;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Message\RequestInterface;
+
+/**
+ * @author Adam Elsodaney <adam.elso@gmail.com>
+ */
+class GithubAccount implements Account
+{
+    /**
+     * @var Client
+     */
+    private $client;
+
+    /**
+     * @var string
+     */
+    private $oauthToken;
+
+    /**
+     * @param Client $client
+     */
+    public function __construct(Client $client)
+    {
+        $this->client = $client;
+    }
+
+    /**
+     * @param string $oauthToken
+     * @param Client $client
+     *
+     * @return static
+     */
+    public static function createWithOauthToken($oauthToken, Client $client)
+    {
+        $account = new static($client);
+        $account->setOauthToken($oauthToken);
+
+        return $account;
+    }
+
+    /**
+     * @param string $oauthToken
+     */
+    public function setOauthToken($oauthToken)
+    {
+        $this->oauthToken = $oauthToken;
+    }
+
+    /**
+     * @return array|Repository[]
+     */
+    public function getAccessibleRepositories()
+    {
+        $repositoriesData = $this->fetchRepositories();
+
+        $repositories = [];
+
+        foreach ($repositoriesData as $repo) {
+            $repository = new Repository();
+
+            $repository
+                ->setFullName($repo['full_name'])
+                ->setHtmlUrl($repo['html_url'])
+                ->setSshUrl($repo['ssh_url'])
+            ;
+
+
+            $repositories[] = $repository;
+        }
+
+        return $repositories;
+    }
+
+    /**
+     * @return array
+     */
+    private function fetchRepositories()
+    {
+        $data = $this->client->send($this->createUserRepositoriesRequest())->json();
+        $orgs = $this->client->send($this->createUserOrganizationRequest())->json();
+
+        foreach ($orgs as $org) {
+            $data = array_merge($data, $this->client->send($this->createUserOrganizationRepositoriesRequest($org))->json());
+        }
+
+        return $data;
+    }
+
+    /**
+     * @return RequestInterface
+     */
+    private function createUserRepositoriesRequest()
+    {
+        return $this->client->createRequest('GET', '/user/repos', [
+            'query' => [
+                'sort' => 'name',
+                'type' => 'all',
+                'access_token' => $this->oauthToken,
+            ]
+        ]);
+    }
+
+    /**
+     * @return RequestInterface
+     */
+    private function createUserOrganizationRequest()
+    {
+        return $this->client->createRequest('GET', '/user/orgs', [
+            'query' => [
+                'access_token' => $this->oauthToken,
+            ]
+        ]);
+    }
+
+    /**
+     * @param array $org
+     *
+     * @return RequestInterface
+     */
+    private function createUserOrganizationRepositoriesRequest(array $org)
+    {
+        return $this->client->createRequest('GET', $org['repos_url'], [
+            'query' => [
+                'type' => 'all',
+                'access_token' => $this->oauthToken,
+            ]
+        ]);
+    }
+}

--- a/src/Transit/WebBundle/Github/Repository.php
+++ b/src/Transit/WebBundle/Github/Repository.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Transit\WebBundle\Github;
+
+/**
+ * GitHub hosted code repository.
+ *
+ * Not to be confused with a repository in Database Abstraction.
+ *
+ * @author Adam Elsodaney <adam.elso@gmail.com>
+ */
+class Repository
+{
+    /**
+     * @var string
+     */
+    private $fullName;
+
+    /**
+     * @var string
+     */
+    private $htmlUrl;
+
+    /**
+     * @var string
+     */
+    private $sshUrl;
+
+    /**
+     * @return string
+     */
+    public function getFullName()
+    {
+        return $this->fullName;
+    }
+
+    /**
+     * @param string $fullName
+     *
+     * @return $this
+     */
+    public function setFullName($fullName)
+    {
+        $this->fullName = $fullName;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getHtmlUrl()
+    {
+        return $this->htmlUrl;
+    }
+
+    /**
+     * @param string $htmlUrl
+     *
+     * @return $this
+     */
+    public function setHtmlUrl($htmlUrl)
+    {
+        $this->htmlUrl = $htmlUrl;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSshUrl()
+    {
+        return $this->sshUrl;
+    }
+
+    /**
+     * @param string $sshUrl
+     *
+     * @return $this
+     */
+    public function setSshUrl($sshUrl)
+    {
+        $this->sshUrl = $sshUrl;
+
+        return $this;
+    }
+}

--- a/src/Transit/WebBundle/Integration/GithubAccountFactory.php
+++ b/src/Transit/WebBundle/Integration/GithubAccountFactory.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Transit\WebBundle\Integration;
+
+use GuzzleHttp\Client;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Transit\WebBundle\Exception\AccountNotLinkedToGithubException;
+use Transit\WebBundle\Github\GithubAccount;
+use Transit\WebBundle\Model\OauthAccount;
+use Transit\WebBundle\Model\UserAccount;
+
+/**
+ * @author Adam Elsodaney <adam.elso@gmail.com>
+ */
+class GithubAccountFactory
+{
+    /**
+     * @var TokenStorageInterface
+     */
+    private $tokenStorage;
+
+    /**
+     * @var Client
+     */
+    private $client;
+
+    /**
+     * @param TokenStorageInterface $tokenStorage
+     */
+    public function __construct(TokenStorageInterface $tokenStorage, Client $client)
+    {
+        $this->tokenStorage = $tokenStorage;
+        $this->client = $client;
+    }
+
+    /**
+     * @return GithubAccount
+     */
+    public function createWithCurrentAuthenticatedUser()
+    {
+        return GithubAccount::createWithOauthToken($this->getOauthAccount()->getAccessToken(), $this->client);
+    }
+
+    /**
+     * @return OauthAccount
+     *
+     * @throws \DomainException                  If the authenticated user is not a Transit User implementation with associated OAuth accounts.
+     * @throws AccountNotLinkedToGithubException If the authenticated user has not connect their account to GitHub.
+     */
+    private function getOauthAccount()
+    {
+        /** @var UserAccount $user */
+        $user = $this->tokenStorage->getToken()->getUser();
+
+        if (! $user instanceof UserAccount) {
+            throw new \DomainException('The model representing the authenticated user must be instance of Transit\WebBundle\Model\UserAccount.');
+        }
+
+        $githubOauthAccount = $user->getGithubOauthAccount();
+
+        if (! $githubOauthAccount instanceof OauthAccount) {
+            throw new AccountNotLinkedToGithubException("User account is not connected to GitHub.");
+        }
+
+        return $githubOauthAccount;
+    }
+}

--- a/src/Transit/WebBundle/Model/OauthAccount.php
+++ b/src/Transit/WebBundle/Model/OauthAccount.php
@@ -30,6 +30,21 @@ class OauthAccount
     protected $userAccount;
 
     /**
+     * @var string
+     */
+    protected $nickname;
+
+    /**
+     * @var string
+     */
+    protected $realName;
+
+    /**
+     * @var string
+     */
+    protected $profilePicture;
+
+    /**
      * @return mixed
      */
     public function getId()
@@ -88,6 +103,14 @@ class OauthAccount
     }
 
     /**
+     * @return string
+     */
+    public function getAccessToken()
+    {
+        return $this->accessToken;
+    }
+
+    /**
      * @param UserAccount $userAccount
      *
      * @return $this
@@ -105,5 +128,65 @@ class OauthAccount
     public function getUserAccount()
     {
         return $this->userAccount;
+    }
+
+    /**
+     * @param $nickname string
+     *
+     * @return $this
+     */
+    public function setNickname($nickname)
+    {
+        $this->nickname = $nickname;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getNickname()
+    {
+        return $this->nickname;
+    }
+
+    /**
+     * @param $realName string
+     *
+     * @return $this
+     */
+    public function setRealName($realName)
+    {
+        $this->realName = $realName;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRealName()
+    {
+        return $this->realName;
+    }
+
+    /**
+     * @param $profilePicture string
+     *
+     * @return $this
+     */
+    public function setProfilePicture($profilePicture)
+    {
+        $this->profilePicture = $profilePicture;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getProfilePicture()
+    {
+        return $this->profilePicture;
     }
 }

--- a/src/Transit/WebBundle/Model/UserAccount.php
+++ b/src/Transit/WebBundle/Model/UserAccount.php
@@ -101,5 +101,21 @@ class UserAccount extends User
         return $this;
     }
 
+    /**
+     * @todo If the same GitHub OAuth account is added twice to a user as a result of renewed permissions, overwrite the previous one.
+     *
+     * @return null|OauthAccount
+     */
+    public function getGithubOauthAccount()
+    {
+        $githubOauth = null;
 
+        foreach ($this->getOauthAccounts() as $oauth) {
+            if ("github" === $oauth->getProvider()) {
+                $githubOauth = $oauth;
+            }
+        }
+
+        return $githubOauth;
+    }
 }

--- a/src/Transit/WebBundle/Repository/ProjectRepository.php
+++ b/src/Transit/WebBundle/Repository/ProjectRepository.php
@@ -12,7 +12,7 @@ use Transit\WebBundle\Model\UserAccount;
 class ProjectRepository extends DocumentRepository
 {
     /**
-     * @param mixed $user
+     * @param UserAccount $user
      *
      * @return $this
      */
@@ -22,5 +22,22 @@ class ProjectRepository extends DocumentRepository
         $project = $this->createNew();
 
         return $project->setOwner($user);
+    }
+
+    /**
+     * @param string $name
+     * @param string $repositoryUrl
+     *
+     * @return Project
+     */
+    public function createNewFromImports($name, $repositoryUrl)
+    {
+        /** @var Project $project */
+        $project = $this->createNew();
+
+        $project->setName($name);
+        $project->setRepositoryUrl($repositoryUrl);
+
+        return $project;
     }
 }

--- a/src/Transit/WebBundle/Resources/config/doctrine/model/OauthAccount.mongodb.xml
+++ b/src/Transit/WebBundle/Resources/config/doctrine/model/OauthAccount.mongodb.xml
@@ -12,6 +12,9 @@
         <field fieldName="identifier" name="identifier" type="string" />
         <field fieldName="provider" name="provider" type="string" />
         <field fieldName="accessToken" name="accessToken" type="string" />
+        <field fieldName="nickname" name="nickname" type="string" />
+        <field fieldName="realName" name="realName" type="string" />
+        <field fieldName="profilePicture" name="profilePicture" type="string" />
 
         <reference-one field="userAccount" fieldName="userAccount" target-document="UserAccount" inversed-by="oauthAccounts" />
 

--- a/src/Transit/WebBundle/Resources/config/doctrine/model/UserAccount.mongodb.xml
+++ b/src/Transit/WebBundle/Resources/config/doctrine/model/UserAccount.mongodb.xml
@@ -11,7 +11,11 @@
         <field fieldName="id" id="true" />
 
         <reference-many field="projects" fieldName="projects" target-document="Project" mapped-by="owner" />
-        <reference-many field="oauthAccounts" fieldName="oauthAccounts" target-document="OauthAccount" mapped-by="userAccount" />
+        <reference-many field="oauthAccounts" fieldName="oauthAccounts" target-document="OauthAccount" mapped-by="userAccount">
+            <cascade>
+                <all />
+            </cascade>
+        </reference-many>
 
     </document>
 </doctrine-mongo-mapping>

--- a/src/Transit/WebBundle/Resources/config/routing.yml
+++ b/src/Transit/WebBundle/Resources/config/routing.yml
@@ -53,6 +53,9 @@ transit_project_create:
         _controller: transit.controller.project:createAction
         _sylius:
             redirect: transit_project_show
+            factory:
+                method: createNewFromImports
+                arguments: [ $name, $repositoryUrl ]
 
 transit_project_show:
     path: /project/{id}
@@ -68,6 +71,13 @@ transit_project_update:
         _sylius:
             redirect: transit_project_show
 
+transit_project_import:
+    path: /project/import/github
+    methods: [GET]
+    defaults:
+        _controller: transit.controller.project:importAction
+        _sylius:
+            redirect: transit_project_show
 
 
 # ./routing/deployment.yml

--- a/src/Transit/WebBundle/Resources/config/services.xml
+++ b/src/Transit/WebBundle/Resources/config/services.xml
@@ -5,8 +5,17 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services
                                http://symfony.com/schema/dic/services/services-1.0.xsd">
 
+    <parameters>
+        <parameter key="transit.version.major" type="constant">Transit\WebBundle\TransitWebBundle::TRANSIT_MAJOR_VERSION</parameter>
+        <parameter key="transit.version.minor" type="constant">Transit\WebBundle\TransitWebBundle::TRANSIT_MINOR_VERSION</parameter>
+    </parameters>
+
     <services>
+        <!-- Third-party -->
+
         <service id="transit.crypt.rsa" class="Crypt_RSA" />
+
+        <!-- Transit -->
 
         <service id="transit.ssh.keygen" class="Transit\WebBundle\Ssh\Keygen">
             <argument type="service" id="transit.crypt.rsa" />
@@ -15,6 +24,26 @@
         <service id="transit.hook.payload_signer" class="Transit\WebBundle\Hook\PayloadSigner">
             <argument>%secret%</argument>
         </service>
+
+
+        <service id="transit.client.github" class="GuzzleHttp\Client">
+            <argument type="collection">
+                <argument key="base_url">https://api.github.com</argument>
+                <argument key="headers" type="collection">
+                    <argument key="Accept">application/vnd.github.moondragon-preview+json</argument>
+                    <argument key="User-Agent">RapidTransit/%transit.version.major%.%transit.version.minor%</argument>
+                </argument>
+            </argument>
+        </service>
+
+        <service id="transit.factory.github_account" class="Transit\WebBundle\Integration\GithubAccountFactory">
+            <argument type="service" id="security.token_storage" />
+            <argument type="service" id="transit.client.github" />
+        </service>
+
+        <service id="transit.provider.account.github" class="Transit\WebBundle\Github\GithubAccount"
+                 factory-service="transit.factory.github_account" factory-method="createWithCurrentAuthenticatedUser"
+        />
 
         <!-- Listeners -->
 
@@ -37,6 +66,11 @@
             <argument>%kernel.root_dir%</argument>
         </service>
 
+        <service id="transit.event_listener.account_not_linked_to_github" class="Transit\WebBundle\EventListener\AccountNotLinkedToGithubListener">
+            <tag name="kernel.event_listener" event="kernel.exception" method="onKernelException" />
+            <argument type="service" id="router" />
+        </service>
+
         <!-- Form Types -->
 
         <service id="transit.form.type.ssh_key_pair" class="%transit.form.type.ssh_key_pair.class%">
@@ -56,7 +90,6 @@
             <argument>%transit.validation_group.deployment%</argument>
             <tag name="form.type" alias="transit_deployment" />
         </service>
-
     </services>
 
 </container>

--- a/src/Transit/WebBundle/Resources/views/Project/import.html.twig
+++ b/src/Transit/WebBundle/Resources/views/Project/import.html.twig
@@ -1,0 +1,13 @@
+{% extends "TransitWebBundle:Project:index.html.twig" %}
+
+{% block content %}
+
+  <h2>{{ "Import new project from GitHub" }}</h2>
+
+  <ul class="side-nav">
+    {% for repo in repositories %}
+      <li><a href="{{ path('transit_project_create', { name: repo.fullName, repositoryUrl: repo.sshUrl }) }}">{{ repo.fullName }}</a></li>
+    {% endfor %}
+  </ul>
+
+{% endblock content %}

--- a/src/Transit/WebBundle/Resources/views/Project/index.html.twig
+++ b/src/Transit/WebBundle/Resources/views/Project/index.html.twig
@@ -4,6 +4,7 @@
   <h2>{{ "Projects" }}</h2>
 
   <a class="button" href="{{ path('transit_project_create') }}">{{ "Create" }}</a>
+  <a class="button" href="{{ path('transit_project_import') }}">{{ "Create From GitHub" }}</a>
 
   <hr />
   {% if projects|length %}

--- a/src/Transit/WebBundle/TransitWebBundle.php
+++ b/src/Transit/WebBundle/TransitWebBundle.php
@@ -10,6 +10,13 @@ use Sylius\Bundle\ResourceBundle\SyliusResourceBundle;
  */
 class TransitWebBundle extends AbstractResourceBundle
 {
+    const TRANSIT_VERSION = '0.1.2-DEV';
+    const TRANSIT_VERSION_ID = '00102';
+    const TRANSIT_MAJOR_VERSION = '0';
+    const TRANSIT_MINOR_VERSION = '1';
+    const TRANSIT_RELEASE_VERSION = '2';
+    const TRANSIT_EXTRA_VERSION = 'DEV';
+
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
As you can now sign in to the app using GitHub, I've added a feature to allow you to quickly add a new project for deployment using repositories that you have access to on GitHub.

Note that this also includes your own private repositories and private repositories of organizations that you are a member of.

If you have any feedback or suggested code changes, let me know. Some additional refactoring will be done to extract the GitHub API request logic from the ProjectController.

![screen shot 2015-01-01 at 16 14 51](https://cloud.githubusercontent.com/assets/5972864/5592640/bb4f6aaa-91d1-11e4-95e7-676cf205aca8.png)

![screen shot 2015-01-01 at 16 15 16](https://cloud.githubusercontent.com/assets/5972864/5592641/bf906254-91d1-11e4-8704-d659675f087e.png)

